### PR TITLE
优化map遍历性能

### DIFF
--- a/motan-core/src/main/java/com/weibo/api/motan/registry/support/AbstractRegistry.java
+++ b/motan-core/src/main/java/com/weibo/api/motan/registry/support/AbstractRegistry.java
@@ -211,8 +211,8 @@ public abstract class AbstractRegistry implements Registry {
         }
 
         // refresh local urls cache
-        for (String nodeType : nodeTypeUrlsInRs.keySet()) {
-            curls.put(nodeType, nodeTypeUrlsInRs.get(nodeType));
+        for (Map.Entry<String, List<URL>> entry : nodeTypeUrlsInRs.entrySet()) {
+            curls.put(entry.getKey(), entry.getValue());
         }
 
         for (List<URL> us : nodeTypeUrlsInRs.values()) {


### PR DESCRIPTION
Map.EntrySet的方式遍历更适合同时需要获取key和value的场景